### PR TITLE
ci: make the release-published notification actually fire

### DIFF
--- a/.github/workflows/notify-publish.yaml
+++ b/.github/workflows/notify-publish.yaml
@@ -1,0 +1,49 @@
+# Tells tamada/api that a release happened, so it can regenerate the site and,
+# when asked, the Homebrew formula.
+#
+# Requirements:
+#
+# - The GitHub App (tamada-pipline-bot) must be installed on this repository and
+#   on tamada/api, with `contents: write` here and `actions: write` there.
+#   It is already installed for repositories owned by tamada.
+# - Two Actions secrets, both taken from the GitHub App settings page:
+#     APP_CLIENT_ID    the App's client ID
+#     APP_PRIVATE_KEY  a private key generated for the App
+#
+# This workflow reacts to the `release: published` event and never calls, or is
+# called by, publish.yaml -- the two know nothing about each other. What makes
+# the event reach here is that publish.yaml un-drafts the release with this same
+# App token: releases published with the automatic GITHUB_TOKEN do not start new
+# workflow runs. See "Triggering a workflow from a workflow" in the Actions docs.
+#
+# Because it keys off the release alone, it also fires when a release is
+# published by hand, and it fires even if the crates.io or container steps of
+# publish.yaml failed.
+name: notify-publish
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      # Generate a one-time token using the private key
+      - name: Generate Token
+        id: generate_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      # Fire the workflow for the other repository using the generated token
+      - name: Trigger API Repository
+        run: |
+          gh workflow run "deploy.yml"     \
+          --repo "tamada/api"              \
+          -f repo=${{ github.repository }} \
+          -f update_brew=true
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -117,15 +117,26 @@ jobs:
   finalize_release:
     needs: publish
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
+      # The release is published with the GitHub App rather than the automatic
+      # GITHUB_TOKEN, because "events triggered by the GITHUB_TOKEN will not
+      # create a new workflow run". Anything that wants to react to
+      # `release: published` -- see notify-publish.yaml -- would never run
+      # otherwise. This job does not know or care who those listeners are.
+      - name: Generate Token
+        id: generate_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Publish the release
         id: publish_release
         run:
           gh release edit --draft=false --repo $GITHUB_REPOSITORY v${{ needs.publish.outputs.tag }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
   publish_crate:
     needs: publish


### PR DESCRIPTION
`notify-publish.yaml` as added could not have fired. Two separate reasons.

## The secret name

```yaml
client-id: ${{ secrets.CLIENT_ID }}
```

This repository has `APP_CLIENT_ID`; there is no `CLIENT_ID`, so
`create-github-app-token` would have received an empty client id and the job would have
failed at its first step. The header comment used a third spelling — it told you to set
`APP_ID`, then referred to `CLIENT_ID` two lines later. It now names what is actually
registered.

## The trigger never reaches it

This is the one that matters. `publish.yaml` creates the release as a draft and then
un-drafts it:

```yaml
run: gh release edit --draft=false --repo $GITHUB_REPOSITORY v${{ needs.publish.outputs.tag }}
env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

From the Actions documentation on triggering a workflow:

> events triggered by the `GITHUB_TOKEN` will not create a new workflow run, with the
> following exceptions: `workflow_dispatch` and `repository_dispatch` events always
> create workflow runs

So the `release: published` event raised by that step reaches no listener. The workflow
would have been dead except for manual `workflow_dispatch` runs.

`finalize_release` now publishes the release with the same GitHub App token instead of
the automatic one.

## Why not add a notify job to publish.yaml

That was considered and rejected deliberately: `publish.yaml` gains no reference to
`notify-publish.yaml`, and `notify-publish.yaml` stays driven purely by the release
event. The two files still know nothing about each other — the only thing that changed
is *who* publishes the release. A release published by hand notifies too.

The cost of keying off the release rather than the pipeline is that the notification
fires even when a later step of `publish.yaml` failed. v0.9.0 was exactly that shape:
`finalize_release` green, `publish_crate` red. Accepted knowingly.

## Verifying before a real release

`workflow_dispatch` is one of the two exceptions to the GITHUB_TOKEN rule, so the notify
path can be exercised on its own once this is on `main`:

```sh
gh workflow run notify-publish.yaml --repo tamada/totebag
```

That confirms token generation and that the App may start `deploy.yml` in `tamada/api`
— the App needs `actions: write` there, and `contents: write` here for the release edit,
which is worth confirming by running it rather than by reading settings.

Note that `release`-triggered workflows only run from the default branch, so nothing
fires automatically until this is merged.

Checked against the repository: `tamada/api` exists, its `deploy.yml` declares
`workflow_dispatch` with the required `repo` and `update_brew` inputs, and
`actions/create-github-app-token@v3` is a current major tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
